### PR TITLE
Fix length variable typo in SocketFactoryTest

### DIFF
--- a/src/rpc-multiplex/tests/Cases/SocketFactoryTest.php
+++ b/src/rpc-multiplex/tests/Cases/SocketFactoryTest.php
@@ -40,7 +40,7 @@ class SocketFactoryTest extends AbstractTestCase
         $factory = new SocketFactory($container, [
             'connect_timeout' => $connectTimeout = rand(5, 10),
             'settings' => [
-                'package_max_length' => $lenght = rand(1000, 9999),
+                'package_max_length' => $length = rand(1000, 9999),
             ],
             'recv_timeout' => $recvTimeout = rand(5, 10),
             'retry_count' => 2,
@@ -67,7 +67,7 @@ class SocketFactoryTest extends AbstractTestCase
         $client = $clients[0];
         $invoker = new ClassInvoker($client);
         $this->assertSame(9501, $invoker->port);
-        $this->assertSame($lenght, $invoker->config['package_max_length']);
+        $this->assertSame($length, $invoker->config['package_max_length']);
         $this->assertSame($connectTimeout, $invoker->config['connect_timeout']);
         $this->assertSame($recvTimeout, $invoker->config['recv_timeout']);
     }
@@ -165,7 +165,7 @@ class SocketFactoryTest extends AbstractTestCase
         $factory = new SocketFactory($container, [
             'connect_timeout' => $connectTimeout = rand(5, 10),
             'settings' => [
-                'package_max_length' => $lenght = rand(1000, 9999),
+                'package_max_length' => $length = rand(1000, 9999),
             ],
             'recv_timeout' => $recvTimeout = rand(5, 10),
             'retry_count' => 2,


### PR DESCRIPTION
## Summary
- rename `$lenght` to `$length`
- update assertions to use corrected variable

## Testing
- `bin/co-phpunit -c phpunit.xml.dist src/rpc-multiplex/tests/Cases/SocketFactoryTest.php` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68404c50a12483319181c6c924e99a6c